### PR TITLE
feat: add Claude Code skills for workshop workflows, fix Phase 2 reset

### DIFF
--- a/.claude/commands/aiops-preflight.md
+++ b/.claude/commands/aiops-preflight.md
@@ -1,0 +1,90 @@
+---
+name: aiops-preflight
+description: "Quick validation before an AIOps workshop demo. Reads credentials from docs/dev-environment.md, runs preflight.yml, and reports whether all required AAP templates and EDA activations are present. TRIGGER when: user wants to verify the workshop environment is ready before a demo."
+---
+
+# AIOps Preflight
+
+Validates that the RHDP AIOps workshop environment is ready before a demo.
+
+## Step 1 — Check Credentials File
+
+Verify `docs/dev-environment.md` exists:
+
+```bash
+test -f docs/dev-environment.md && echo "✅ docs/dev-environment.md found" || echo "❌ docs/dev-environment.md not found"
+```
+
+If the file does not exist, stop and tell the user:
+
+> ❌ docs/dev-environment.md not found. Copy docs/dev-environment.md.example and fill in your RHDP instance credentials before running preflight.
+
+## Step 2 — Run Preflight
+
+Read `docs/dev-environment.md` and extract credentials using this table, then run `preflight.yml` with those values set as environment variables:
+
+| Variable | Section | Field |
+|----------|---------|-------|
+| `CONTROLLER_HOST` | `## AAP` | `URL` |
+| `CONTROLLER_USERNAME` | `## AAP` | `Username` |
+| `CONTROLLER_PASSWORD` | `## AAP` | `Password` |
+| `SPLUNK_HOST` | `## Splunk` | `URL` |
+| `SPLUNK_USERNAME` | `## Splunk` | `Username` |
+| `SPLUNK_PASSWORD` | `## Splunk` | `Password` |
+| `EDA_WEBHOOK_URL` | `## EDA Webhook` | `URL` |
+| `BASTION_HOST` | `## SSH Bastion` | `Host` |
+| `BASTION_PORT` | `## SSH Bastion` | `Port` |
+| `BASTION_USER` | `## SSH Bastion` | `Username` |
+| `BASTION_PASSWORD` | `## SSH Bastion` | `Password` |
+
+```bash
+python3 << 'EOF'
+import re, subprocess, os, sys
+
+content = open('docs/dev-environment.md').read()
+
+def get(section, field):
+    m = re.search(rf'^## {re.escape(section)}$', content, re.MULTILINE)
+    if not m:
+        return ''
+    rest = content[m.end():]
+    n = re.search(r'^## ', rest, re.MULTILINE)
+    sec = rest[:n.start() if n else len(rest)]
+    fm = re.search(rf'\*\*{re.escape(field)}:\*\*\s*(.+)', sec)
+    return fm.group(1).strip() if fm else ''
+
+env = {**os.environ,
+    'CONTROLLER_HOST':     get('AAP', 'URL'),
+    'CONTROLLER_USERNAME': get('AAP', 'Username'),
+    'CONTROLLER_PASSWORD': get('AAP', 'Password'),
+    'SPLUNK_HOST':         get('Splunk', 'URL'),
+    'SPLUNK_USERNAME':     get('Splunk', 'Username'),
+    'SPLUNK_PASSWORD':     get('Splunk', 'Password'),
+    'EDA_WEBHOOK_URL':     get('EDA Webhook', 'URL'),
+    'BASTION_HOST':        get('SSH Bastion', 'Host'),
+    'BASTION_PORT':        get('SSH Bastion', 'Port'),
+    'BASTION_USER':        get('SSH Bastion', 'Username'),
+    'BASTION_PASSWORD':    get('SSH Bastion', 'Password'),
+}
+
+result = subprocess.run(
+    ['ansible-playbook', '-i', 'inventories/rhdp-sample/', 'playbooks/preflight.yml'],
+    env=env
+)
+sys.exit(result.returncode)
+EOF
+```
+
+## Step 3 — Report Results
+
+On success:
+
+```
+✅ Preflight passed — workshop environment is ready.
+
+  AAP:         <CONTROLLER_HOST>
+  Splunk:      <SPLUNK_HOST>
+  EDA Webhook: <EDA_WEBHOOK_URL>
+```
+
+On failure, show the specific task that failed from Ansible output and the most likely fix.

--- a/.claude/commands/aiops-reset.md
+++ b/.claude/commands/aiops-reset.md
@@ -1,0 +1,116 @@
+---
+name: aiops-reset
+description: "Resets all three AIOps workshop phases to a known-good state between customer sessions. Reads credentials from docs/dev-environment.md and runs all three reset playbooks. TRIGGER when: user wants to return the workshop to a known-good state before the next demo session."
+---
+
+# AIOps Reset
+
+Resets all three workshop phases to a known-good state. Run between customer sessions.
+
+## Step 1 — Check Credentials File
+
+Verify `docs/dev-environment.md` exists:
+
+```bash
+test -f docs/dev-environment.md && echo "✅ docs/dev-environment.md found" || echo "❌ docs/dev-environment.md not found"
+```
+
+If the file does not exist, stop and tell the user:
+
+> ❌ docs/dev-environment.md not found. Copy docs/dev-environment.md.example and fill in your RHDP instance credentials before running reset.
+
+## Step 2 — Run All Reset Playbooks
+
+Read `docs/dev-environment.md` and extract credentials using this table, then run all three reset playbooks — stopping immediately if any fails:
+
+| Variable | Section | Field |
+|----------|---------|-------|
+| `CONTROLLER_HOST` | `## AAP` | `URL` |
+| `CONTROLLER_USERNAME` | `## AAP` | `Username` |
+| `CONTROLLER_PASSWORD` | `## AAP` | `Password` |
+| `SPLUNK_HOST` | `## Splunk` | `URL` |
+| `SPLUNK_USERNAME` | `## Splunk` | `Username` |
+| `SPLUNK_PASSWORD` | `## Splunk` | `Password` |
+| `EDA_WEBHOOK_URL` | `## EDA Webhook` | `URL` |
+| `BASTION_HOST` | `## SSH Bastion` | `Host` |
+| `BASTION_PORT` | `## SSH Bastion` | `Port` |
+| `BASTION_USER` | `## SSH Bastion` | `Username` |
+| `BASTION_PASSWORD` | `## SSH Bastion` | `Password` |
+| `NETWORK_HOST` | `## SSH (cisco-rtr1 — via bastion)` | `Internal IP` |
+| `NETWORK_USERNAME` | `## SSH (cisco-rtr1 — via bastion)` | `Username` |
+| `NETWORK_PASSWORD` | `## SSH (cisco-rtr1 — via bastion)` | `Password` |
+
+> **Note — Phase 2 reset:** `reset_phase2_network.yml` reconnects tunnel0 on cisco-rtr1 via the SSH bastion. It requires `BASTION_HOST`, `BASTION_PORT`, `BASTION_USER`, and `BASTION_PASSWORD` to be set correctly.
+
+```bash
+python3 << 'EOF'
+import re, subprocess, os, sys
+
+content = open('docs/dev-environment.md').read()
+
+def get(section, field):
+    m = re.search(rf'^## {re.escape(section)}$', content, re.MULTILINE)
+    if not m:
+        return ''
+    rest = content[m.end():]
+    n = re.search(r'^## ', rest, re.MULTILINE)
+    sec = rest[:n.start() if n else len(rest)]
+    fm = re.search(rf'\*\*{re.escape(field)}:\*\*\s*(.+)', sec)
+    return fm.group(1).strip() if fm else ''
+
+env = {**os.environ,
+    'CONTROLLER_HOST':     get('AAP', 'URL'),
+    'CONTROLLER_USERNAME': get('AAP', 'Username'),
+    'CONTROLLER_PASSWORD': get('AAP', 'Password'),
+    'SPLUNK_HOST':         get('Splunk', 'URL'),
+    'SPLUNK_USERNAME':     get('Splunk', 'Username'),
+    'SPLUNK_PASSWORD':     get('Splunk', 'Password'),
+    'EDA_WEBHOOK_URL':     get('EDA Webhook', 'URL'),
+    'BASTION_HOST':        get('SSH Bastion', 'Host'),
+    'BASTION_PORT':        get('SSH Bastion', 'Port'),
+    'BASTION_USER':        get('SSH Bastion', 'Username'),
+    'BASTION_PASSWORD':    get('SSH Bastion', 'Password'),
+    'NETWORK_HOST':        get('SSH (cisco-rtr1 — via bastion)', 'Internal IP'),
+    'NETWORK_USERNAME':    get('SSH (cisco-rtr1 — via bastion)', 'Username'),
+    'NETWORK_PASSWORD':    get('SSH (cisco-rtr1 — via bastion)', 'Password'),
+}
+
+steps = [
+    ('Phase 1 — Apache AIOps', 'playbooks/reset_phase1_apache.yml'),
+    ('Phase 2 — Network AIOps','playbooks/reset_phase2_network.yml'),
+    ('Phase 3 — Windows AIOps','playbooks/reset_phase3_windows.yml'),
+]
+
+results = []
+for label, playbook in steps:
+    print(f'\n{"="*60}')
+    print(f'Resetting {label}...')
+    print('='*60)
+    r = subprocess.run(
+        ['ansible-playbook', '-i', 'inventories/rhdp-sample/', playbook],
+        env=env
+    )
+    if r.returncode != 0:
+        print(f'\n❌ {label} reset failed — stopping.')
+        for done_label, _ in results:
+            print(f'  ✅ {done_label}')
+        print(f'  ❌ {label} — FAILED')
+        sys.exit(r.returncode)
+    results.append((label, playbook))
+    print(f'✅ {label} reset complete')
+
+print('\n' + '='*60)
+print('Reset complete. All phases are in known-good state.\n')
+for label, _ in results:
+    print(f'  ✅ {label}')
+print('\nReady for the next demo session.')
+EOF
+```
+
+## Step 3 — On Failure
+
+Show which phase failed and display the Ansible error output. Suggest re-running the single failed reset playbook directly after fixing the issue:
+
+```bash
+ansible-playbook -i inventories/rhdp-sample/ playbooks/<failed-reset-playbook>.yml
+```

--- a/.claude/commands/aiops-setup.md
+++ b/.claude/commands/aiops-setup.md
@@ -1,0 +1,114 @@
+---
+name: aiops-setup
+description: "Full setup sequence for a fresh RHDP AIOps workshop environment. Reads credentials from docs/dev-environment.md, runs preflight, then sets up all three phases (Apache, Network, Windows) in sequence. Stops on first failure. TRIGGER when: user has a fresh RHDP deployment and wants to run the full workshop setup."
+---
+
+# AIOps Setup
+
+Full setup sequence for a fresh RHDP AIOps workshop environment. Runs preflight then all three phase setup playbooks in order.
+
+## Step 1 — Check Credentials File
+
+Verify `docs/dev-environment.md` exists:
+
+```bash
+test -f docs/dev-environment.md && echo "✅ docs/dev-environment.md found" || echo "❌ docs/dev-environment.md not found"
+```
+
+If the file does not exist, stop and tell the user:
+
+> ❌ docs/dev-environment.md not found. Copy docs/dev-environment.md.example and fill in your RHDP instance credentials before running setup.
+
+## Step 2 — Run Full Setup Sequence
+
+Read `docs/dev-environment.md` and extract credentials using this table, then run all four playbooks in sequence — stopping immediately if any fails:
+
+| Variable | Section | Field |
+|----------|---------|-------|
+| `CONTROLLER_HOST` | `## AAP` | `URL` |
+| `CONTROLLER_USERNAME` | `## AAP` | `Username` |
+| `CONTROLLER_PASSWORD` | `## AAP` | `Password` |
+| `SPLUNK_HOST` | `## Splunk` | `URL` |
+| `SPLUNK_USERNAME` | `## Splunk` | `Username` |
+| `SPLUNK_PASSWORD` | `## Splunk` | `Password` |
+| `EDA_WEBHOOK_URL` | `## EDA Webhook` | `URL` |
+| `BASTION_HOST` | `## SSH Bastion` | `Host` |
+| `BASTION_PORT` | `## SSH Bastion` | `Port` |
+| `BASTION_USER` | `## SSH Bastion` | `Username` |
+| `BASTION_PASSWORD` | `## SSH Bastion` | `Password` |
+
+```bash
+python3 << 'EOF'
+import re, subprocess, os, sys
+
+content = open('docs/dev-environment.md').read()
+
+def get(section, field):
+    m = re.search(rf'^## {re.escape(section)}$', content, re.MULTILINE)
+    if not m:
+        return ''
+    rest = content[m.end():]
+    n = re.search(r'^## ', rest, re.MULTILINE)
+    sec = rest[:n.start() if n else len(rest)]
+    fm = re.search(rf'\*\*{re.escape(field)}:\*\*\s*(.+)', sec)
+    return fm.group(1).strip() if fm else ''
+
+env = {**os.environ,
+    'CONTROLLER_HOST':     get('AAP', 'URL'),
+    'CONTROLLER_USERNAME': get('AAP', 'Username'),
+    'CONTROLLER_PASSWORD': get('AAP', 'Password'),
+    'SPLUNK_HOST':         get('Splunk', 'URL'),
+    'SPLUNK_USERNAME':     get('Splunk', 'Username'),
+    'SPLUNK_PASSWORD':     get('Splunk', 'Password'),
+    'EDA_WEBHOOK_URL':     get('EDA Webhook', 'URL'),
+    'BASTION_HOST':        get('SSH Bastion', 'Host'),
+    'BASTION_PORT':        get('SSH Bastion', 'Port'),
+    'BASTION_USER':        get('SSH Bastion', 'Username'),
+    'BASTION_PASSWORD':    get('SSH Bastion', 'Password'),
+}
+
+steps = [
+    ('Preflight',              'playbooks/preflight.yml'),
+    ('Phase 1 — Apache AIOps', 'playbooks/setup_phase1_apache.yml'),
+    ('Phase 2 — Network AIOps','playbooks/setup_phase2_network.yml'),
+    ('Phase 3 — Windows AIOps','playbooks/setup_phase3_windows.yml'),
+]
+
+results = []
+for label, playbook in steps:
+    print(f'\n{"="*60}')
+    print(f'Running {label}...')
+    print('='*60)
+    r = subprocess.run(
+        ['ansible-playbook', '-i', 'inventories/rhdp-sample/', playbook],
+        env=env
+    )
+    if r.returncode != 0:
+        print(f'\n❌ {label} failed — stopping.')
+        for done_label, _ in results:
+            print(f'  ✅ {done_label}')
+        print(f'  ❌ {label} — FAILED')
+        sys.exit(r.returncode)
+    results.append((label, playbook))
+    print(f'✅ {label} complete')
+
+print('\n' + '='*60)
+print('Setup complete.\n')
+for label, _ in results:
+    print(f'  ✅ {label}')
+print("""
+Demo entry points:
+  Apache:  Run "❌ Break Apache" in AAP
+  Network: SSH cisco-rtr1, shut tunnel0
+  Windows: Launch "Simulate AD Account Creation" or "Simulate Windows Firewall Toggle"
+""")
+EOF
+```
+
+## Step 3 — On Failure
+
+Show which phase failed and display the Ansible error output. Do not suggest re-running the full sequence — suggest re-running the single failed playbook directly after fixing the issue:
+
+```bash
+ansible-playbook -i inventories/rhdp-sample/ playbooks/<failed-playbook>.yml
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `reset_phase2_network.yml` — replace `ansible.netcommon.cli_config` (Paramiko fails to handle ProxyCommand and cannot resolve internal hostname `cisco-rtr1`) with `ansible.builtin.shell` + `sshpass -e` piping IOS config commands directly over SSH via the bastion ProxyCommand (fixes issue #9)
+- `inventories/rhdp-sample/group_vars/all.yml` — add `network_host`, `network_username`, `network_password` env var lookups (required for Phase 2 reset)
+- `.claude/commands/aiops-reset.md` — extract `NETWORK_HOST`, `NETWORK_USERNAME`, `NETWORK_PASSWORD` from `docs/dev-environment.md` before running reset playbooks
+
+### Claude Code Skills
+- `.claude/commands/aiops-preflight.md` — `/aiops-preflight` slash command: reads credentials from `docs/dev-environment.md` and runs `preflight.yml`
+- `.claude/commands/aiops-setup.md` — `/aiops-setup` slash command: runs preflight + all three phase setup playbooks in sequence, stops on first failure
+- `.claude/commands/aiops-reset.md` — `/aiops-reset` slash command: runs all three reset playbooks in sequence, stops on first failure
+
 ### Added
 - Initial repo scaffold: README, LICENSE, CODE_OF_CONDUCT, CONTRIBUTING, CHANGELOG
 - ansible.cfg, .gitignore, collections/requirements.yml

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ cp -r inventories/rhdp-sample/ inventories/rhdp-<customer>/
 | Phase 2 | Network AIOps | ✅ Tested | Splunk TCP input, Network Router Setup job, Splunk alert → EDA webhook |
 | Phase 3 | Windows AIOps | ✅ Tested | Verifies Windows job templates and EDA activation |
 
+## Claude Code Skills
+
+If you're using [Claude Code](https://claude.ai/code), three slash commands are available that read credentials automatically from `docs/dev-environment.md`:
+
+| Command | What it does |
+|---------|-------------|
+| `/aiops-preflight` | Validates the environment is ready before a demo |
+| `/aiops-setup` | Runs preflight + all three phase setup playbooks in sequence |
+| `/aiops-reset` | Resets all three phases to known-good state |
+
+No manual `export` of environment variables needed — each command reads `docs/dev-environment.md` directly.
+
 ## License
 
 MIT — see [LICENSE](LICENSE)

--- a/inventories/rhdp-sample/group_vars/all.yml
+++ b/inventories/rhdp-sample/group_vars/all.yml
@@ -19,5 +19,10 @@ bastion_port: "{{ lookup('env', 'BASTION_PORT') | default('22') }}"
 bastion_user: "{{ lookup('env', 'BASTION_USER') | default('lab-user') }}"
 bastion_password: "{{ lookup('env', 'BASTION_PASSWORD') }}"
 
+# Cisco router (required for Phase 2 reset — accessed via bastion)
+network_host:     "{{ lookup('env', 'NETWORK_HOST') }}"
+network_username: "{{ lookup('env', 'NETWORK_USERNAME') | default('admin') }}"
+network_password: "{{ lookup('env', 'NETWORK_PASSWORD') }}"
+
 # Workshop defaults
 organization: "Default"

--- a/playbooks/reset_phase2_network.yml
+++ b/playbooks/reset_phase2_network.yml
@@ -20,20 +20,17 @@
           no_log: true
 
         - name: Restore tunnel0 on cisco-rtr1 (no shut)
-          ansible.netcommon.cli_config:
-            config: |
-              interface tunnel0
-               no shutdown
-          vars:
-            ansible_host: "cisco-rtr1"
-            ansible_user: "{{ lookup('env', 'NETWORK_USERNAME') | default('admin') }}"
-            ansible_password: "{{ lookup('env', 'NETWORK_PASSWORD') | mandatory }}"
-            ansible_network_os: cisco.ios.ios
-            ansible_connection: network_cli
-            ansible_ssh_common_args: >-
-              -o ProxyCommand='sshpass -f {{ bastion_pass_file.path }} ssh -p {{ bastion_port }}
-              -o StrictHostKeyChecking=no {{ bastion_user }}@{{ bastion_host }} -W %h:%p'
-              -o StrictHostKeyChecking=no
+          ansible.builtin.shell: |
+            printf 'configure terminal\ninterface tunnel0\nno shutdown\nend\nwrite memory\n' | \
+            sshpass -e \
+              ssh -tt \
+              -o "ProxyCommand=sshpass -f {{ bastion_pass_file.path }} ssh -p {{ bastion_port }} -o StrictHostKeyChecking=no {{ bastion_user }}@{{ bastion_host }} -W %h:%p" \
+              -o StrictHostKeyChecking=no \
+              -o ConnectTimeout=30 \
+              {{ network_username }}@{{ network_host }}
+          environment:
+            SSHPASS: "{{ network_password }}"
+          no_log: true
 
       always:
         - name: Remove bastion password temp file


### PR DESCRIPTION
## Summary

- Adds three Claude Code slash commands (`.claude/commands/`) that read credentials from `docs/dev-environment.md` automatically — no manual `export` required
- Fixes `reset_phase2_network.yml`: replaces `ansible.netcommon.cli_config` with `ansible.builtin.shell` + `sshpass -e` to work around a Paramiko ProxyCommand limitation that prevented cisco-rtr1 from being reached
- Adds `network_host`, `network_username`, `network_password` env var lookups to `group_vars/all.yml`

## Skills

| Command | What it does |
|---------|-------------|
| `/aiops-preflight` | Validates AAP + Splunk + EDA are ready before a demo |
| `/aiops-setup` | Runs preflight + all three phase setup playbooks in sequence, stops on first failure |
| `/aiops-reset` | Resets all three phases to known-good state between sessions |

## Test plan

- [x] `/aiops-preflight` — tested against live RHDP, AAP reachable, all 13 job templates found
- [x] `/aiops-setup` — tested against live RHDP, all four steps pass (preflight + phases 1–3)
- [x] `/aiops-reset` — tested against live RHDP, all three resets pass including tunnel0 restore on cisco-rtr1

Closes #8
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)