### PR TITLE
feat: skills collect RHDP credentials and create dev-environment.md if missing

### DIFF
--- a/.claude/commands/aiops-preflight.md
+++ b/.claude/commands/aiops-preflight.md
@@ -9,15 +9,63 @@ Validates that the RHDP AIOps workshop environment is ready before a demo.
 
 ## Step 1 — Check Credentials File
 
-Verify `docs/dev-environment.md` exists:
-
 ```bash
-test -f docs/dev-environment.md && echo "✅ docs/dev-environment.md found" || echo "❌ docs/dev-environment.md not found"
+test -f docs/dev-environment.md && echo "found" || echo "missing"
 ```
 
-If the file does not exist, stop and tell the user:
+If the file exists, proceed to Step 2.
 
-> ❌ docs/dev-environment.md not found. Copy docs/dev-environment.md.example and fill in your RHDP instance credentials before running preflight.
+If the file is missing, tell the user you'll help create it and ask them to provide all of the following values in one reply (they can find these on their RHDP instance details page):
+
+- AAP URL (e.g. `https://controller-xxxx.apps.cluster.rhdp.net`)
+- AAP password (username is always `admin`)
+- Splunk URL (e.g. `https://splunk-xxxx.apps.cluster.rhdp.net`)
+- Splunk password (username is always `admin`)
+- EDA Webhook URL (e.g. `https://eda-webhook-xxxx.apps.cluster.rhdp.net`)
+- SSH Bastion host (e.g. `ssh.cluster.rhdp.net`)
+- SSH Bastion port (a 5-digit number)
+- SSH Bastion password (username is always `lab-user`)
+- Cisco router internal IP (e.g. `10.x.x.x`)
+- Cisco router password (username is always `admin`)
+
+Once the user provides the values, write `docs/dev-environment.md` with this exact format, substituting the actual values:
+
+```
+# Dev Environment — Current RHDP Instance
+
+This file is gitignored. Never commit it.
+
+## AAP
+
+- **URL:** <aap-url>
+- **Username:** admin
+- **Password:** <aap-password>
+
+## Splunk
+
+- **URL:** <splunk-url>
+- **Username:** admin
+- **Password:** <splunk-password>
+
+## EDA Webhook
+
+- **URL:** <eda-webhook-url>
+
+## SSH Bastion
+
+- **Host:** <bastion-host>
+- **Port:** <bastion-port>
+- **Username:** lab-user
+- **Password:** <bastion-password>
+
+## SSH (cisco-rtr1 — via bastion)
+
+- **Internal IP:** <cisco-internal-ip>
+- **Username:** admin
+- **Password:** <cisco-password>
+```
+
+Confirm the file was written, then proceed to Step 2.
 
 ## Step 2 — Run Preflight
 

--- a/.claude/commands/aiops-reset.md
+++ b/.claude/commands/aiops-reset.md
@@ -9,15 +9,63 @@ Resets all three workshop phases to a known-good state. Run between customer ses
 
 ## Step 1 — Check Credentials File
 
-Verify `docs/dev-environment.md` exists:
-
 ```bash
-test -f docs/dev-environment.md && echo "✅ docs/dev-environment.md found" || echo "❌ docs/dev-environment.md not found"
+test -f docs/dev-environment.md && echo "found" || echo "missing"
 ```
 
-If the file does not exist, stop and tell the user:
+If the file exists, proceed to Step 2.
 
-> ❌ docs/dev-environment.md not found. Copy docs/dev-environment.md.example and fill in your RHDP instance credentials before running reset.
+If the file is missing, tell the user you'll help create it and ask them to provide all of the following values in one reply (they can find these on their RHDP instance details page):
+
+- AAP URL (e.g. `https://controller-xxxx.apps.cluster.rhdp.net`)
+- AAP password (username is always `admin`)
+- Splunk URL (e.g. `https://splunk-xxxx.apps.cluster.rhdp.net`)
+- Splunk password (username is always `admin`)
+- EDA Webhook URL (e.g. `https://eda-webhook-xxxx.apps.cluster.rhdp.net`)
+- SSH Bastion host (e.g. `ssh.cluster.rhdp.net`)
+- SSH Bastion port (a 5-digit number)
+- SSH Bastion password (username is always `lab-user`)
+- Cisco router internal IP (e.g. `10.x.x.x`)
+- Cisco router password (username is always `admin`)
+
+Once the user provides the values, write `docs/dev-environment.md` with this exact format, substituting the actual values:
+
+```
+# Dev Environment — Current RHDP Instance
+
+This file is gitignored. Never commit it.
+
+## AAP
+
+- **URL:** <aap-url>
+- **Username:** admin
+- **Password:** <aap-password>
+
+## Splunk
+
+- **URL:** <splunk-url>
+- **Username:** admin
+- **Password:** <splunk-password>
+
+## EDA Webhook
+
+- **URL:** <eda-webhook-url>
+
+## SSH Bastion
+
+- **Host:** <bastion-host>
+- **Port:** <bastion-port>
+- **Username:** lab-user
+- **Password:** <bastion-password>
+
+## SSH (cisco-rtr1 — via bastion)
+
+- **Internal IP:** <cisco-internal-ip>
+- **Username:** admin
+- **Password:** <cisco-password>
+```
+
+Confirm the file was written, then proceed to Step 2.
 
 ## Step 2 — Run All Reset Playbooks
 

--- a/.claude/commands/aiops-setup.md
+++ b/.claude/commands/aiops-setup.md
@@ -9,15 +9,63 @@ Full setup sequence for a fresh RHDP AIOps workshop environment. Runs preflight 
 
 ## Step 1 — Check Credentials File
 
-Verify `docs/dev-environment.md` exists:
-
 ```bash
-test -f docs/dev-environment.md && echo "✅ docs/dev-environment.md found" || echo "❌ docs/dev-environment.md not found"
+test -f docs/dev-environment.md && echo "found" || echo "missing"
 ```
 
-If the file does not exist, stop and tell the user:
+If the file exists, proceed to Step 2.
 
-> ❌ docs/dev-environment.md not found. Copy docs/dev-environment.md.example and fill in your RHDP instance credentials before running setup.
+If the file is missing, tell the user you'll help create it and ask them to provide all of the following values in one reply (they can find these on their RHDP instance details page):
+
+- AAP URL (e.g. `https://controller-xxxx.apps.cluster.rhdp.net`)
+- AAP password (username is always `admin`)
+- Splunk URL (e.g. `https://splunk-xxxx.apps.cluster.rhdp.net`)
+- Splunk password (username is always `admin`)
+- EDA Webhook URL (e.g. `https://eda-webhook-xxxx.apps.cluster.rhdp.net`)
+- SSH Bastion host (e.g. `ssh.cluster.rhdp.net`)
+- SSH Bastion port (a 5-digit number)
+- SSH Bastion password (username is always `lab-user`)
+- Cisco router internal IP (e.g. `10.x.x.x`)
+- Cisco router password (username is always `admin`)
+
+Once the user provides the values, write `docs/dev-environment.md` with this exact format, substituting the actual values:
+
+```
+# Dev Environment — Current RHDP Instance
+
+This file is gitignored. Never commit it.
+
+## AAP
+
+- **URL:** <aap-url>
+- **Username:** admin
+- **Password:** <aap-password>
+
+## Splunk
+
+- **URL:** <splunk-url>
+- **Username:** admin
+- **Password:** <splunk-password>
+
+## EDA Webhook
+
+- **URL:** <eda-webhook-url>
+
+## SSH Bastion
+
+- **Host:** <bastion-host>
+- **Port:** <bastion-port>
+- **Username:** lab-user
+- **Password:** <bastion-password>
+
+## SSH (cisco-rtr1 — via bastion)
+
+- **Internal IP:** <cisco-internal-ip>
+- **Username:** admin
+- **Password:** <cisco-password>
+```
+
+Confirm the file was written, then proceed to Step 2.
 
 ## Step 2 — Run Full Setup Sequence
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Docs (issue #7)
 - `images/rhdp-catalog-item.png` — screenshot of the RHDP catalog item embedded in README
-- `README.md` — Getting Started section (Step 1 order catalog item → Step 2 clone + `claude .` → Step 3 populate credentials → Step 4 `/aiops-setup`); correct showroom section names to Part 1/2/3
+- `README.md` — Getting Started section simplified to 3 steps (order → clone + `claude .` → `/aiops-setup`); Claude handles credential collection automatically; correct showroom section names to Part 1/2/3
+- `.claude/commands/aiops-preflight.md`, `aiops-setup.md`, `aiops-reset.md` — if `docs/dev-environment.md` is missing, ask the user for RHDP credentials and create the file automatically instead of stopping with an error
 - `docs/dev-environment.md.example` — template with all required fields and placeholder values
 - `docs/troubleshooting.md` — 10 common failure modes with diagnosis and fix steps
 - `README.md` — add RHDP catalog item name, workshop module map, `dev-environment.md.example` setup step, link to troubleshooting guide

--- a/README.md
+++ b/README.md
@@ -19,18 +19,13 @@ cd aiops-workshop-prep
 claude .
 ```
 
-**Step 3 — Populate your credentials:**
-
-```bash
-cp docs/dev-environment.md.example docs/dev-environment.md
-# edit docs/dev-environment.md with the URLs and passwords from your RHDP instance details page
-```
-
-**Step 4 — Run setup:**
+**Step 3 — Run setup:**
 
 ```
 /aiops-setup
 ```
+
+Claude will ask for your RHDP credentials, create `docs/dev-environment.md`, and run all three phase setup playbooks in sequence.
 
 See [Prerequisites](#prerequisites) for manual setup without Claude Code.
 


### PR DESCRIPTION
## Summary

If `docs/dev-environment.md` is missing when any aiops skill is invoked, Claude now asks the user for all RHDP credentials in a single prompt and writes the file — instead of stopping with an error telling the user to do it manually.

Getting Started is now 3 steps:
1. Order the RHDP catalog item
2. `git clone` + `claude .`
3. `/aiops-setup` — Claude handles credential collection and all setup

## Test plan

- [ ] Run `/aiops-setup` with no `docs/dev-environment.md` present — verify Claude asks for credentials and creates the file
- [ ] Run `/aiops-setup` again with file present — verify it skips collection and runs playbooks directly
- [ ] Same for `/aiops-preflight` and `/aiops-reset`

🤖 Generated with [Claude Code](https://claude.com/claude-code)