### PR TITLE
fix: remove pre-population of Remediation Workflow from Phase 1 setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 - `CLAUDE.md` — add issue #1 to open issues table (replaces closed duplicate #13)
 - `.claude/commands/aiops-setup.md`, `aiops-preflight.md`, `aiops-reset.md` — add Splunk API token to credential collection prompt and `docs/dev-environment.md` template
 
+### Fixed
+- `setup_phase1_apache.yml` — remove "Create Remediation Workflow" task (fixes issue #15): the Remediation Workflow is populated mid-demo by the AI Insights workflow, not at setup time; trying to pre-populate it fails on fresh RHDP instances where \`🧠 Lightspeed Remediation Playbook Generator\` does not yet exist
+
 ### Docs (issue #7)
 - `images/rhdp-catalog-item.png` — screenshot of the RHDP catalog item embedded in README
 - `README.md` — Getting Started section simplified to 3 steps (order → clone + `claude .` → `/aiops-setup`); Claude handles credential collection automatically; correct showroom section names to Part 1/2/3

--- a/playbooks/setup_phase1_apache.yml
+++ b/playbooks/setup_phase1_apache.yml
@@ -50,51 +50,6 @@
         controller_password: "{{ controller_password }}"
         validate_certs: "{{ validate_certs }}"
 
-    - name: Create Remediation Workflow
-      ansible.controller.workflow_job_template:
-        name: "Remediation Workflow"
-        organization: "{{ organization }}"
-        destroy_current_nodes: true
-        workflow_nodes:
-          - identifier: remediation-generator
-            unified_job_template:
-              name: "🧠 Lightspeed Remediation Playbook Generator"
-              organization:
-                name: "{{ organization }}"
-              type: job_template
-            related:
-              success_nodes:
-                - identifier: commit-fix
-          - identifier: commit-fix
-            unified_job_template:
-              name: "🧾 Commit Fix to Gitea"
-              organization:
-                name: "{{ organization }}"
-              type: job_template
-            related:
-              success_nodes:
-                - identifier: project-sync
-          - identifier: project-sync
-            unified_job_template:
-              name: "Lightspeed-Playbooks"
-              organization:
-                name: "{{ organization }}"
-              type: project
-            related:
-              success_nodes:
-                - identifier: build-httpd-remediation
-          - identifier: build-httpd-remediation
-            unified_job_template:
-              name: "⚙️ Build HTTPD Remediation Template"
-              organization:
-                name: "{{ organization }}"
-              type: job_template
-        state: present
-        controller_host: "{{ controller_host }}"
-        controller_username: "{{ controller_username }}"
-        controller_password: "{{ controller_password }}"
-        validate_certs: "{{ validate_certs }}"
-
     - name: Ensure Apache is in known-good state
       ansible.controller.job_launch:
         job_template: "✅ Restore Apache"


### PR DESCRIPTION
## Problem

`setup_phase1_apache.yml` had a task "Create Remediation Workflow" that tried to add nodes referencing `🧠 Lightspeed Remediation Playbook Generator`. This template does not exist on a fresh RHDP instance — it is created dynamically mid-demo when the AI Insights workflow runs `⚙️ Build Ansible Lightspeed Job Template`.

The original test instance (ocpv06) had the template because the demo had already been run there. A fresh instance (ocpv10) does not, causing Phase 1 setup to fail.

## Fix

Remove the "Create Remediation Workflow" task entirely. The workflow already exists (upstream creates it empty) and is populated automatically during the demo.

## Test plan

- [x] Phase 1 setup passes on fresh RHDP instance (ocpv10)
- [x] Phase 2 and Phase 3 also pass — full setup complete

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)