### PR TITLE
fix: create Lightspeed generator template before Remediation Workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - `.claude/commands/aiops-setup.md`, `aiops-preflight.md`, `aiops-reset.md` — add Splunk API token to credential collection prompt and `docs/dev-environment.md` template
 
 ### Fixed
-- `setup_phase1_apache.yml` — remove "Create Remediation Workflow" task (fixes issue #15): the Remediation Workflow is populated mid-demo by the AI Insights workflow, not at setup time; trying to pre-populate it fails on fresh RHDP instances where \`🧠 Lightspeed Remediation Playbook Generator\` does not yet exist
+- `setup_phase1_apache.yml` — create `🧠 Lightspeed Remediation Playbook Generator` job template before creating the Remediation Workflow (fixes issue #15): the template does not exist on a fresh RHDP instance and must be created pointing at the `AI-EDA` project before the workflow nodes can reference it
 
 ### Docs (issue #7)
 - `images/rhdp-catalog-item.png` — screenshot of the RHDP catalog item embedded in README

--- a/playbooks/setup_phase1_apache.yml
+++ b/playbooks/setup_phase1_apache.yml
@@ -50,6 +50,69 @@
         controller_password: "{{ controller_password }}"
         validate_certs: "{{ validate_certs }}"
 
+    - name: Create Lightspeed Remediation Playbook Generator job template
+      ansible.controller.job_template:
+        name: "🧠 Lightspeed Remediation Playbook Generator"
+        job_type: run
+        organization: "{{ organization }}"
+        inventory: "Demo Inventory"
+        project: "AI-EDA"
+        playbook: "playbooks/lightspeed_generate.yml"
+        credentials:
+          - "AAP"
+          - "ansible-vault"
+        execution_environment: "Default execution environment"
+        state: present
+        controller_host: "{{ controller_host }}"
+        controller_username: "{{ controller_username }}"
+        controller_password: "{{ controller_password }}"
+        validate_certs: "{{ validate_certs }}"
+
+    - name: Create Remediation Workflow
+      ansible.controller.workflow_job_template:
+        name: "Remediation Workflow"
+        organization: "{{ organization }}"
+        destroy_current_nodes: true
+        workflow_nodes:
+          - identifier: remediation-generator
+            unified_job_template:
+              name: "🧠 Lightspeed Remediation Playbook Generator"
+              organization:
+                name: "{{ organization }}"
+              type: job_template
+            related:
+              success_nodes:
+                - identifier: commit-fix
+          - identifier: commit-fix
+            unified_job_template:
+              name: "🧾 Commit Fix to Gitea"
+              organization:
+                name: "{{ organization }}"
+              type: job_template
+            related:
+              success_nodes:
+                - identifier: project-sync
+          - identifier: project-sync
+            unified_job_template:
+              name: "Lightspeed-Playbooks"
+              organization:
+                name: "{{ organization }}"
+              type: project
+            related:
+              success_nodes:
+                - identifier: build-httpd-remediation
+          - identifier: build-httpd-remediation
+            unified_job_template:
+              name: "⚙️ Build HTTPD Remediation Template"
+              organization:
+                name: "{{ organization }}"
+              type: job_template
+        state: present
+        controller_host: "{{ controller_host }}"
+        controller_username: "{{ controller_username }}"
+        controller_password: "{{ controller_password }}"
+        validate_certs: "{{ validate_certs }}"
+
     - name: Ensure Apache is in known-good state
       ansible.controller.job_launch:
         job_template: "✅ Restore Apache"


### PR DESCRIPTION
## Problem

On a fresh RHDP instance, `🧠 Lightspeed Remediation Playbook Generator` does not exist, so creating the Remediation Workflow nodes fails. The previous fix (PR #16) removed the Remediation Workflow task entirely, but that left Part 1 Section 2 incomplete.

## Fix

Add a task before the Remediation Workflow to create `🧠 Lightspeed Remediation Playbook Generator` pointing at the `AI-EDA` project (`playbooks/lightspeed_generate.yml`, credentials: `AAP` + `ansible-vault`). The Remediation Workflow task then succeeds because the template exists.

Phase 1 now has 4 tasks:
1. Create AI Insights and Lightspeed prompt generation workflow
2. Create Lightspeed Remediation Playbook Generator job template ← new
3. Create Remediation Workflow
4. Ensure Apache is in known-good state

## Test plan

- [x] All 4 Phase 1 tasks pass on fresh RHDP instance (ocpv10)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)